### PR TITLE
Fix master CI workflow

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Test with pytest (full)
       if: github.ref == 'refs/heads/master'
       run: |
-        py.test -v --tb=short
+        poetry run py.test -v --tb=short
     - name: Test with pytest (fast)
       if: github.ref != 'refs/heads/master'
       run: |


### PR DESCRIPTION
Fixes a bug in the previous PR, where I failed to convert the continuous integration tests that only run when a branch is merged to master to run in poetry.