### PR TITLE
Support CMIP6 data

### DIFF
--- a/docs/database.md
+++ b/docs/database.md
@@ -94,7 +94,9 @@ Typically, all the files to be indexed are under a single root
 directory. (Such a root directory contains one or more subdirectories, 
 one per "location", which is a province or territory.)
 
-<version> is the broad ensembles of files, such as "CMIP5" or "CMIP6".
+`version` is the broad ensemble of files. Currently "CMIP5 and "CMIP6"
+are accepted as `version`s. Each version should be in a separate
+master directory.
 
 Run:
 
@@ -115,3 +117,24 @@ index_location_collection -d <DSN> -v <version> <path> | tee wxfs-indexing.log
 ```
 
 Or the equivalent bash scripting to read the location paths out of a file.
+
+### Note on location table entries
+
+At present, CMIP5 and CMIP6 locations use different levels of precision in
+their coordinates, which causes them to be indexed as different locations. For
+example, consider the following two locations:
+
+| location_id | name               | province | country | code    | longitude | latitude | elevation |
+|-------------|--------------------|----------|---------|---------|-----------|----------|-----------|
+| 219         | Churchill Falls AP | NL       | CAN     | 7100020 | -64.1064  | 53.5619  | 439.5     |
+| 707         | CHURCHILL FALLS    | NL       | CAN     | 7100020 | -64.11    | 53.56    | 439.5     |
+
+To a human, these appear to be the same location, but they will be indexed as
+two separate locations, since their coordinates are not strictly equal.
+
+At present this unintuitive behaviour does not present an issue, as we always
+display CMIP5 and CMIP6 data files seperately. In fact, this bug is beneficial,
+as it allows to to preserve the official location names from both the CMIP5 and
+CMIP6 datasets.
+
+But if use cases or data formats change, it may need to be resolved in the future.

--- a/docs/database.md
+++ b/docs/database.md
@@ -82,6 +82,13 @@ of weather files into the database.
    ```shell
    python database.py -d <DSN> populate
    ```
+You may have to explicitly grant table access to the read-only account,
+like this:
+
+   ```sql
+   GRANT SELECT ON ALL TABLES IN SCHEMA public TO wxfs_ro;
+   ```
+
 
 ## Index files into the database
 

--- a/docs/database.md
+++ b/docs/database.md
@@ -94,11 +94,13 @@ Typically, all the files to be indexed are under a single root
 directory. (Such a root directory contains one or more subdirectories, 
 one per "location", which is a province or territory.)
 
+<version> is the broad ensembles of files, such as "CMIP5" or "CMIP6".
+
 Run:
 
 ```shell
 for i in <root dir>/*; do \
-  index_location_collection -d <DSN> $i; 
+  index_location_collection -d <DSN> -v <version> $i; 
 done 2>&1 | tee wxfs-indexing.log
 ```
 
@@ -109,7 +111,7 @@ scattered in widely different directories, you will have to obtain each
 location directory path and do the following for each such path:
 
 ```shell
-index_location_collection -d <DSN> <path> | tee wxfs-indexing.log
+index_location_collection -d <DSN> -v <version> <path> | tee wxfs-indexing.log
 ```
 
 Or the equivalent bash scripting to read the location paths out of a file.

--- a/scripts/index_location
+++ b/scripts/index_location
@@ -23,7 +23,7 @@ if __name__ == "__main__":
         "into index database"
     )
     parser.add_argument("-d", "--dsn", help="DSN for index database")
-    parser.add_argument("-v", "--version", help="Data version (ie CMIP6, CMIP5)")
+    parser.add_argument("-v", "--version", help="Data version", choices=["CMIP5", "CMIP6"])
     parser.add_argument("directories", nargs="+", help="Directories to process")
     args = parser.parse_args()
 

--- a/scripts/index_location
+++ b/scripts/index_location
@@ -5,13 +5,13 @@ from sqlalchemy.orm import sessionmaker
 from wxfs.indexer import index_location
 
 
-def main(dsn, directories):
+def main(dsn, version, directories):
     engine = create_engine(dsn)
     Session = sessionmaker(bind=engine)
     session = Session()
 
     for directory in directories:
-        index_location(session, directory)
+        index_location(session, version, directory)
 
     session.commit()  # TODO: Move inside index_location?
     session.close()
@@ -23,7 +23,8 @@ if __name__ == "__main__":
         "into index database"
     )
     parser.add_argument("-d", "--dsn", help="DSN for index database")
+    parser.add_argument("-v", "--version", help="Data version (ie CMIP6, CMIP5)")
     parser.add_argument("directories", nargs="+", help="Directories to process")
     args = parser.parse_args()
 
-    main(dsn=args.dsn, directories=args.directories)
+    main(dsn=args.dsn, version=args.version, directories=args.directories)

--- a/scripts/index_location
+++ b/scripts/index_location
@@ -6,6 +6,9 @@ from wxfs.indexer import index_location
 
 
 def main(dsn, version, directories):
+    """Indexes all files in a single directory. The files must all correspond to
+    the same location (read from the files) and share a version (input as an 
+    argument). Files may be either data files or summary files."""
     engine = create_engine(dsn)
     Session = sessionmaker(bind=engine)
     session = Session()

--- a/scripts/index_location_collection
+++ b/scripts/index_location_collection
@@ -22,7 +22,7 @@ if __name__ == "__main__":
         "into index database"
     )
     parser.add_argument("-d", "--dsn", help="DSN for index database")
-    parser.add_argument("-v", "--version", help="Data version (ie CMIP6, CMIP5)")
+    parser.add_argument("-v", "--version", help="Data version", choices=["CMIP5", "CMIP6"])
     parser.add_argument("directory", help="Collection directory")
     args = parser.parse_args()
 

--- a/scripts/index_location_collection
+++ b/scripts/index_location_collection
@@ -5,12 +5,12 @@ from sqlalchemy.orm import sessionmaker
 from wxfs.indexer import index_location_collection
 
 
-def main(dsn, directory):
+def main(dsn, version, directory):
     engine = create_engine(dsn)
     Session = sessionmaker(bind=engine)
     session = Session()
 
-    index_location_collection(session, directory)
+    index_location_collection(session, version, directory)
 
     session.commit()  # TODO: Move inside index_location?
     session.close()
@@ -22,7 +22,8 @@ if __name__ == "__main__":
         "into index database"
     )
     parser.add_argument("-d", "--dsn", help="DSN for index database")
+    parser.add_argument("-v", "--version", help="Data version (ie CMIP6, CMIP5)")
     parser.add_argument("directory", help="Collection directory")
     args = parser.parse_args()
 
-    main(dsn=args.dsn, directory=args.directory)
+    main(dsn=args.dsn, version=args.version, directory=args.directory)

--- a/scripts/index_location_collection
+++ b/scripts/index_location_collection
@@ -6,6 +6,13 @@ from wxfs.indexer import index_location_collection
 
 
 def main(dsn, version, directory):
+    """Indexes a master directory containing one or more location directories.
+    Attempts to index all files in each location directory inside the master
+    directory. All files in a location directory must correspond to
+    the same location (read from the files). All files in the
+    master directory must share a version (input as an 
+    argument)."""
+
     engine = create_engine(dsn)
     Session = sessionmaker(bind=engine)
     session = Session()

--- a/tests/indexer/conftest.py
+++ b/tests/indexer/conftest.py
@@ -11,13 +11,22 @@ import wxfs.database
 
 @pytest.fixture()
 def make_wx_file(tmpdir):
-    def make(year, city, code, lon, lat, elev):
-        p = tmpdir.join(f"{year}s_CAN_BC_{city}.{code}_CWEC2016.epw")
-        p.write(
-            f"""LOCATION,{city},BC,CAN,CWEC2016,{code},{lat},{lon},-8.0,{elev} | Morphed:TAS,RHS,DWPT,PS | File Version: 2.1 | Creation Date: 2020-06-23
+    def make(year, city, code, lon, lat, elev, scenario = "RCP85", format = 1):
+        if format == 1:
+            p = tmpdir.join(f"{year}s_CAN_BC_{city}.{code}_CWEC2016.epw")
+            p.write(
+                f"""LOCATION,{city},BC,CAN,CWEC2016,{code},{lat},{lon},-8.0,{elev} | Morphed:TAS,RHS,DWPT,PS | File Version: 2.1 | Creation Date: 2020-06-23
 OTHER STUFF
 """
-        )
+            )
+        elif format == 2:
+            p = tmpdir.join(f"MORPHED_{scenario}_{year}s_CAN_BC_{city}.{code}_CWEC2016.epw")
+            p.write(f"""LOCATION,{city},BC,CAN,CWEC2016,{code},{lat},{lon},-8.0,{elev}
+COMMENTS 1, Future-shifted CWEC2020 EPW file for the {year} using projections from the {scenario} scenario.
+COMMENTS 2, Future-shifted variables:TAS,RHS,DWPT,PS, File Version: 3.0, Creation Date: 2020-06-23
+OTHER STUFF
+""")
+            
         return os.path.join(p.dirname, p.basename)
 
     return make

--- a/tests/indexer/conftest.py
+++ b/tests/indexer/conftest.py
@@ -11,7 +11,16 @@ import wxfs.database
 
 @pytest.fixture()
 def make_wx_file(tmpdir):
-    def make(year, city, code, lon, lat, elev, scenario = "RCP85", format = 1):
+    """WX Files may have their metadata specified in either of two formats, referred
+    to here as "format 1" and "format 2". All files currently in the database
+    are format 2, but format 1 is maintained in tests and code in case.
+    Format 1 puts more metadata in the LOCATION line; format 2 spreads it across multiple
+    COMMENTS lines.
+    Separately to metadata format, some files specify the scenario in the filename and
+    some don't. In order to test both options easily, Format 1 files are generated
+    without the scenario in the filename, but format 2 files are generated with it."""
+
+    def make(year, city, code, lon, lat, elev, scenario="RCP85", format=1):
         if format == 1:
             p = tmpdir.join(f"{year}s_CAN_BC_{city}.{code}_CWEC2016.epw")
             p.write(
@@ -20,13 +29,17 @@ OTHER STUFF
 """
             )
         elif format == 2:
-            p = tmpdir.join(f"MORPHED_{scenario}_{year}s_CAN_BC_{city}.{code}_CWEC2016.epw")
-            p.write(f"""LOCATION,{city},BC,CAN,CWEC2016,{code},{lat},{lon},-8.0,{elev}
+            p = tmpdir.join(
+                f"MORPHED_{scenario}_{year}s_CAN_BC_{city}.{code}_CWEC2016.epw"
+            )
+            p.write(
+                f"""LOCATION,{city},BC,CAN,CWEC2016,{code},{lat},{lon},-8.0,{elev}
 COMMENTS 1, Future-shifted CWEC2020 EPW file for the {year} using projections from the {scenario} scenario.
 COMMENTS 2, Future-shifted variables:TAS,RHS,DWPT,PS, File Version: 3.0, Creation Date: 2020-06-23
 OTHER STUFF
-""")
-            
+"""
+            )
+
         return os.path.join(p.dirname, p.basename)
 
     return make

--- a/tests/indexer/test_file_parsing.py
+++ b/tests/indexer/test_file_parsing.py
@@ -32,7 +32,7 @@ def test_get_wx_file_info(year, city, code, lon, lat, elev, make_wx_file):
         "creationDate": datetime.datetime(2020, 6, 23),
         "dataSource": "CWEC2016",
         "designDataType": "TMY",
-        "scenario": "RCP8.5",
+        "scenario": "RCP85",
         "timePeriodStart": datetime.datetime(year - 10, 1, 1),
         "timePeriodEnd": datetime.datetime(year + 20, 1, 1)
         - datetime.timedelta(seconds=1),

--- a/tests/indexer/test_file_parsing.py
+++ b/tests/indexer/test_file_parsing.py
@@ -16,8 +16,9 @@ from wxfs.indexer.file_parsing import (
         (2050, "Elsewhere", "11111", 51.1, -125.2, 1000.0),
     ],
 )
-def test_get_wx_file_info(year, city, code, lon, lat, elev, make_wx_file):
-    with open(make_wx_file(year, city, code, lon, lat, elev), "r") as wx_file:
+@pytest.mark.parametrize("version", [1, 2])
+def test_get_wx_file_info(year, city, code, lon, lat, elev, version, make_wx_file):
+    with open(make_wx_file(year, city, code, lon, lat, elev, "RCP85", version), "r") as wx_file:
         location_info, wx_file_info = get_wx_file_info(wx_file)
     assert location_info == {
         "city": city,
@@ -32,7 +33,7 @@ def test_get_wx_file_info(year, city, code, lon, lat, elev, make_wx_file):
         "creationDate": datetime.datetime(2020, 6, 23),
         "dataSource": "CWEC2016",
         "designDataType": "TMY",
-        "scenario": "RCP85",
+        "scenario": "RCP 8.5",
         "timePeriodStart": datetime.datetime(year - 10, 1, 1),
         "timePeriodEnd": datetime.datetime(year + 20, 1, 1)
         - datetime.timedelta(seconds=1),

--- a/tests/indexer/test_file_parsing.py
+++ b/tests/indexer/test_file_parsing.py
@@ -18,7 +18,9 @@ from wxfs.indexer.file_parsing import (
 )
 @pytest.mark.parametrize("version", [1, 2])
 def test_get_wx_file_info(year, city, code, lon, lat, elev, version, make_wx_file):
-    with open(make_wx_file(year, city, code, lon, lat, elev, "RCP85", version), "r") as wx_file:
+    with open(
+        make_wx_file(year, city, code, lon, lat, elev, "RCP85", version), "r"
+    ) as wx_file:
         location_info, wx_file_info = get_wx_file_info(wx_file)
     assert location_info == {
         "city": city,

--- a/tests/indexer/test_indexer.py
+++ b/tests/indexer/test_indexer.py
@@ -35,7 +35,7 @@ def test_index_one_wx_file(year, city, code, lon, lat, elev, version, db_session
     assert wx_file.creationDate == datetime.datetime(2020, 6, 23)
     assert wx_file.dataSource == "CWEC2016"
     assert wx_file.designDataType == "TMY"
-    assert wx_file.scenario == "RCP8.5"
+    assert wx_file.scenario == "RCP85"
     print("timePeriodStart", wx_file.timePeriodStart)
     assert wx_file.timePeriodStart.year == year - 10
     print("timePeriodEnd", wx_file.timePeriodEnd)

--- a/tests/indexer/test_indexer.py
+++ b/tests/indexer/test_indexer.py
@@ -35,7 +35,7 @@ def test_index_one_wx_file(year, city, code, lon, lat, elev, version, db_session
     assert wx_file.creationDate == datetime.datetime(2020, 6, 23)
     assert wx_file.dataSource == "CWEC2016"
     assert wx_file.designDataType == "TMY"
-    assert wx_file.scenario == "RCP85"
+    assert wx_file.scenario == "RCP 8.5"
     print("timePeriodStart", wx_file.timePeriodStart)
     assert wx_file.timePeriodStart.year == year - 10
     print("timePeriodEnd", wx_file.timePeriodEnd)

--- a/tests/indexer/test_indexer.py
+++ b/tests/indexer/test_indexer.py
@@ -14,7 +14,9 @@ from wxfs.database import Location, WxFile, Version
     ],
 )
 @pytest.mark.parametrize("version", ["cmip5", "cmip6"])
-def test_index_one_wx_file(year, city, code, lon, lat, elev, version, db_session, make_wx_file):
+def test_index_one_wx_file(
+    year, city, code, lon, lat, elev, version, db_session, make_wx_file
+):
     wx_file_file_path = make_wx_file(year, city, code, lon, lat, elev)
     index_wx_file(db_session, version, wx_file_file_path)
 
@@ -28,7 +30,7 @@ def test_index_one_wx_file(year, city, code, lon, lat, elev, version, db_session
     assert float(location.elevation) == elev
 
     ver = db_session.query(Version).one()
-    assert ver.name == version 
+    assert ver.name == version
 
     wx_file = db_session.query(WxFile).one()
     assert wx_file.location == location

--- a/tests/indexer/test_indexer.py
+++ b/tests/indexer/test_indexer.py
@@ -13,9 +13,10 @@ from wxfs.database import Location, WxFile
         (2050, "Elsewhere", "11111", 51.1, -125.2, 1000.0),
     ],
 )
-def test_index_one_wx_file(year, city, code, lon, lat, elev, db_session, make_wx_file):
+@pytest.mark.parametrize("version", ["cmip5", "cmip6"])
+def test_index_one_wx_file(year, city, code, lon, lat, elev, version, db_session, make_wx_file):
     wx_file_file_path = make_wx_file(year, city, code, lon, lat, elev)
-    index_wx_file(db_session, wx_file_file_path)
+    index_wx_file(db_session, version, wx_file_file_path)
 
     location = db_session.query(Location).one()
     assert location.city == city
@@ -25,6 +26,9 @@ def test_index_one_wx_file(year, city, code, lon, lat, elev, db_session, make_wx
     assert float(location.longitude) == lon
     assert float(location.latitude) == lat
     assert float(location.elevation) == elev
+
+    ver = db.session.query(Version).one()
+    assert ver.name == version 
 
     wx_file = db_session.query(WxFile).one()
     assert wx_file.location == location
@@ -51,7 +55,7 @@ def test_index_many_wx_files(
 ):
     for year in years:
         wx_file_file_path = make_wx_file(year, city, code, lon, lat, elev)
-        index_wx_file(db_session, wx_file_file_path)
+        index_wx_file(db_session, "cmip5", wx_file_file_path)
 
     station_q = db_session.query(Location)
     assert station_q.count() == 1

--- a/tests/indexer/test_indexer.py
+++ b/tests/indexer/test_indexer.py
@@ -3,7 +3,7 @@ import pytest
 import datetime
 
 from wxfs.indexer import index_wx_file
-from wxfs.database import Location, WxFile
+from wxfs.database import Location, WxFile, Version
 
 
 @pytest.mark.parametrize(
@@ -27,7 +27,7 @@ def test_index_one_wx_file(year, city, code, lon, lat, elev, version, db_session
     assert float(location.latitude) == lat
     assert float(location.elevation) == elev
 
-    ver = db.session.query(Version).one()
+    ver = db_session.query(Version).one()
     assert ver.name == version 
 
     wx_file = db_session.query(WxFile).one()

--- a/tests/indexer/test_indexer.py
+++ b/tests/indexer/test_indexer.py
@@ -3,7 +3,7 @@ import pytest
 import datetime
 
 from wxfs.indexer import index_wx_file
-from wxfs.database import Location, WxFile, Version
+from wxfs.database import Location, WxFile
 
 
 @pytest.mark.parametrize(
@@ -13,7 +13,7 @@ from wxfs.database import Location, WxFile, Version
         (2050, "Elsewhere", "11111", 51.1, -125.2, 1000.0),
     ],
 )
-@pytest.mark.parametrize("version", ["cmip5", "cmip6"])
+@pytest.mark.parametrize("version", ["CMIP5", "CMIP6"])
 def test_index_one_wx_file(
     year, city, code, lon, lat, elev, version, db_session, make_wx_file
 ):
@@ -29,9 +29,6 @@ def test_index_one_wx_file(
     assert float(location.latitude) == lat
     assert float(location.elevation) == elev
 
-    ver = db_session.query(Version).one()
-    assert ver.name == version
-
     wx_file = db_session.query(WxFile).one()
     assert wx_file.location == location
     assert wx_file.creationDate == datetime.datetime(2020, 6, 23)
@@ -43,6 +40,7 @@ def test_index_one_wx_file(
     print("timePeriodEnd", wx_file.timePeriodEnd)
     assert wx_file.timePeriodEnd.year == year + 19
     assert wx_file.ensembleStatistic == "average"
+    assert wx_file.version == version
 
 
 @pytest.mark.parametrize(
@@ -57,7 +55,7 @@ def test_index_many_wx_files(
 ):
     for year in years:
         wx_file_file_path = make_wx_file(year, city, code, lon, lat, elev)
-        index_wx_file(db_session, "cmip5", wx_file_file_path)
+        index_wx_file(db_session, "CMIP5", wx_file_file_path)
 
     station_q = db_session.query(Location)
     assert station_q.count() == 1

--- a/wxfs/api/files.py
+++ b/wxfs/api/files.py
@@ -41,7 +41,7 @@ def single_item_rep(file):
             **rep_common,
             # TODO: It is probably not right to fill these in statically.
             #  See TODO in ORM definition
-            "scenario": "RCP8.5",
+            "scenario": file.scenario,
             "ensembleStatistic": "multiple",
             "timePeriod": "all",
             "variables": "all thermodynamic",

--- a/wxfs/api/files.py
+++ b/wxfs/api/files.py
@@ -35,7 +35,7 @@ def single_item_rep(file):
             "variables": file.variables,
             "anomaly": file.anomaly,
             "smoothing": file.smoothing,
-            "version": file.version,
+            "version": file.version.name,
         }
     elif file.fileType == "summary":
         return {
@@ -43,7 +43,7 @@ def single_item_rep(file):
             # TODO: It is probably not right to fill these in statically.
             #  See TODO in ORM definition
             "scenario": file.scenario,
-            "version": file.version,
+            "version": file.version.name,
             "ensembleStatistic": "multiple",
             "timePeriod": "all",
             "variables": "all thermodynamic",

--- a/wxfs/api/files.py
+++ b/wxfs/api/files.py
@@ -35,6 +35,7 @@ def single_item_rep(file):
             "variables": file.variables,
             "anomaly": file.anomaly,
             "smoothing": file.smoothing,
+            "version": file.version,
         }
     elif file.fileType == "summary":
         return {
@@ -42,6 +43,7 @@ def single_item_rep(file):
             # TODO: It is probably not right to fill these in statically.
             #  See TODO in ORM definition
             "scenario": file.scenario,
+            "version": file.version,
             "ensembleStatistic": "multiple",
             "timePeriod": "all",
             "variables": "all thermodynamic",

--- a/wxfs/api/files.py
+++ b/wxfs/api/files.py
@@ -35,7 +35,7 @@ def single_item_rep(file):
             "variables": file.variables,
             "anomaly": file.anomaly,
             "smoothing": file.smoothing,
-            "version": file.version.name,
+            "version": file.version,
         }
     elif file.fileType == "summary":
         return {
@@ -43,7 +43,7 @@ def single_item_rep(file):
             # TODO: It is probably not right to fill these in statically.
             #  See TODO in ORM definition
             "scenario": file.scenario,
-            "version": file.version.name,
+            "version": file.version,
             "ensembleStatistic": "multiple",
             "timePeriod": "all",
             "variables": "all thermodynamic",

--- a/wxfs/api/locations.py
+++ b/wxfs/api/locations.py
@@ -40,9 +40,7 @@ def collection_rep(locations):
 
 
 def listing():
-    locations = (
-        get_app_session().query(Location).order_by(Location.id.asc()).all()
-    )
+    locations = get_app_session().query(Location).order_by(Location.id.asc()).all()
     return collection_rep(locations)
 
 

--- a/wxfs/asgi.py
+++ b/wxfs/asgi.py
@@ -1,4 +1,3 @@
 from wxfs import create_app
 
-print("#### asgi")
 connexion_app, flask_app, app_db = create_app()

--- a/wxfs/asgi.py
+++ b/wxfs/asgi.py
@@ -1,4 +1,4 @@
 from wxfs import create_app
 
-print("#### wsgi")
+print("#### asgi")
 connexion_app, flask_app, app_db = create_app()

--- a/wxfs/database/__init__.py
+++ b/wxfs/database/__init__.py
@@ -35,14 +35,6 @@ class Location(Base):
     elevation = Column(Numeric, nullable=True)
 
 
-class Version(Base):
-    """A version describes a set of data files with a common history"""
-
-    __tablename__ = "versions"
-    id = Column("version_id", Integer, primary_key=True, nullable=False)
-    name = Column(String(64), nullable=False)
-
-
 class File(Base):
     """Base type for polymorphic file objects."""
 
@@ -66,9 +58,10 @@ class File(Base):
         nullable=False,
     )
 
+    version = Column(Enum("CMIP5", "CMIP6", name="version"), nullable=False)
+
     # Relationships
     location_id = Column(Integer, ForeignKey("locations.location_id"))
-    version_id = Column(Integer, ForeignKey("versions.version_id"))
 
     __mapper_args__ = {
         "polymorphic_identity": "files",
@@ -96,7 +89,6 @@ class SummaryFile(File):
 
     # Relationships
     location = relationship("Location", backref="summary_files")
-    version = relationship("Version", backref="summary_files")
 
     __mapper_args__ = {"polymorphic_identity": "summary"}
 
@@ -141,6 +133,5 @@ class WxFile(File):
 
     # Relationships
     location = relationship("Location", backref="wx_files")
-    version = relationship("Version", backref="wx_files")
 
     __mapper_args__ = {"polymorphic_identity": "weather"}

--- a/wxfs/database/__init__.py
+++ b/wxfs/database/__init__.py
@@ -38,7 +38,7 @@ class Version(Base):
     """A version describes a ser of data files with a common history"""
     
     __tablename__ = "versions"
-    id = Column("version_id", Integer, primary_key=True, nuuable=False)
+    id = Column("version_id", Integer, primary_key=True, nullable=False)
     name = Column(String(12), nullable=False)
     description = Column(String(64), nullable=True)
 

--- a/wxfs/database/__init__.py
+++ b/wxfs/database/__init__.py
@@ -53,6 +53,13 @@ class File(Base):
         Enum("summary", "weather", name="fileType"), nullable=False
     )
     filepath = Column(String(2048), nullable=False)
+    
+    scenario = Column(
+        Enum("RCP26", "RCP45", "RCP85", 
+             "SSP585", "SSP245", "SSP126", "multiple", 
+             name="scenario"), 
+        nullable=False
+    )
 
     # Relationships
     location_id = Column(Integer, ForeignKey("locations.location_id"))
@@ -80,7 +87,7 @@ class SummaryFile(File):
         nullable=False,
     )
     # TODO: Add attributes scenario, ensembleStatistic(s), timePeriod(s), variables.
-    #  These should be raised up to File where appropriate (scenario, variables, ...).
+    #  These should be raised up to File where appropriate (variables, ...).
 
     # Relationships
     location = relationship("Location", backref="summary_files")
@@ -108,9 +115,7 @@ class WxFile(File):
         Enum("TMY", "XMY", "TSY", "AMY", "design day", name="designDataType"),
         nullable=False,
     )
-    scenario = Column(
-        Enum("RCP2.6", "RCP4.5", "RCP8.5", name="scenario"), nullable=False
-    )
+
     timePeriodStart = Column(DateTime, nullable=False)
     timePeriodEnd = Column(DateTime, nullable=False)
     ensembleStatistic = Column(

--- a/wxfs/database/__init__.py
+++ b/wxfs/database/__init__.py
@@ -1,6 +1,7 @@
 """ORM for the Wx Files database.
 
 """
+
 # TODO: Datetime of indexing? Do we care?
 
 from sqlalchemy import (
@@ -36,7 +37,7 @@ class Location(Base):
 
 class Version(Base):
     """A version describes a ser of data files with a common history"""
-    
+
     __tablename__ = "versions"
     id = Column("version_id", Integer, primary_key=True, nullable=False)
     name = Column(String(12), nullable=False)
@@ -48,16 +49,21 @@ class File(Base):
     __tablename__ = "files"
     id = Column("file_id", Integer, primary_key=True, nullable=False)
     # Discriminator for polymorphic type
-    fileType = Column(
-        Enum("summary", "weather", name="fileType"), nullable=False
-    )
+    fileType = Column(Enum("summary", "weather", name="fileType"), nullable=False)
     filepath = Column(String(2048), nullable=False)
-    
+
     scenario = Column(
-        Enum("RCP 2.6", "RCP 4.5", "RCP 8.5", 
-             "SSP5-8.5", "SSP2-4.5", "SSP1-2.6", "multiple", 
-             name="scenario"), 
-        nullable=False
+        Enum(
+            "RCP 2.6",
+            "RCP 4.5",
+            "RCP 8.5",
+            "SSP5-8.5",
+            "SSP2-4.5",
+            "SSP1-2.6",
+            "multiple",
+            name="scenario",
+        ),
+        nullable=False,
     )
 
     # Relationships
@@ -90,7 +96,7 @@ class SummaryFile(File):
 
     # Relationships
     location = relationship("Location", backref="summary_files")
-    version = relationship("Version", backref='summary_files')
+    version = relationship("Version", backref="summary_files")
 
     __mapper_args__ = {"polymorphic_identity": "summary"}
 

--- a/wxfs/database/__init__.py
+++ b/wxfs/database/__init__.py
@@ -34,6 +34,15 @@ class Location(Base):
     elevation = Column(Numeric, nullable=True)
 
 
+class Version(Base):
+    """A version describes a ser of data files with a common history"""
+    
+    __tablename__ = "versions"
+    id = Column("version_id", Integer, primary_key=True, nuuable=False)
+    name = Column(String(12), nullable=False)
+    description = Column(String(64), nullable=True)
+
+
 class File(Base):
     """Base type for polymorphic file objects."""
 
@@ -47,6 +56,7 @@ class File(Base):
 
     # Relationships
     location_id = Column(Integer, ForeignKey("locations.location_id"))
+    version_id = Column(Integer, ForeignKey("versions.version_id"))
 
     __mapper_args__ = {
         "polymorphic_identity": "files",

--- a/wxfs/database/__init__.py
+++ b/wxfs/database/__init__.py
@@ -40,7 +40,6 @@ class Version(Base):
     __tablename__ = "versions"
     id = Column("version_id", Integer, primary_key=True, nullable=False)
     name = Column(String(12), nullable=False)
-    description = Column(String(64), nullable=True)
 
 
 class File(Base):

--- a/wxfs/database/__init__.py
+++ b/wxfs/database/__init__.py
@@ -56,7 +56,7 @@ class File(Base):
     
     scenario = Column(
         Enum("RCP 2.6", "RCP 4.5", "RCP 8.5", 
-             "SSP5 85", "SSP245", "SSP126", "multiple", 
+             "SSP5-8.5", "SSP2-4.5", "SSP1-2.6", "multiple", 
              name="scenario"), 
         nullable=False
     )

--- a/wxfs/database/__init__.py
+++ b/wxfs/database/__init__.py
@@ -55,8 +55,8 @@ class File(Base):
     filepath = Column(String(2048), nullable=False)
     
     scenario = Column(
-        Enum("RCP26", "RCP45", "RCP85", 
-             "SSP585", "SSP245", "SSP126", "multiple", 
+        Enum("RCP 2.6", "RCP 4.5", "RCP 8.5", 
+             "SSP5 85", "SSP245", "SSP126", "multiple", 
              name="scenario"), 
         nullable=False
     )

--- a/wxfs/database/__init__.py
+++ b/wxfs/database/__init__.py
@@ -36,7 +36,7 @@ class Location(Base):
 
 
 class Version(Base):
-    """A version describes a ser of data files with a common history"""
+    """A version describes a set of data files with a common history"""
 
     __tablename__ = "versions"
     id = Column("version_id", Integer, primary_key=True, nullable=False)

--- a/wxfs/database/__init__.py
+++ b/wxfs/database/__init__.py
@@ -40,7 +40,7 @@ class Version(Base):
 
     __tablename__ = "versions"
     id = Column("version_id", Integer, primary_key=True, nullable=False)
-    name = Column(String(12), nullable=False)
+    name = Column(String(64), nullable=False)
 
 
 class File(Base):

--- a/wxfs/database/__init__.py
+++ b/wxfs/database/__init__.py
@@ -84,6 +84,7 @@ class SummaryFile(File):
 
     # Relationships
     location = relationship("Location", backref="summary_files")
+    version = relationship("Version", backref='summary_files')
 
     __mapper_args__ = {"polymorphic_identity": "summary"}
 
@@ -130,5 +131,6 @@ class WxFile(File):
 
     # Relationships
     location = relationship("Location", backref="wx_files")
+    version = relationship("Version", backref="wx_files")
 
     __mapper_args__ = {"polymorphic_identity": "weather"}

--- a/wxfs/database/demo/database.py
+++ b/wxfs/database/demo/database.py
@@ -1,7 +1,7 @@
 from argparse import ArgumentParser
 import re
 from datetime import datetime
-from sqlalchemy import create_engine
+from sqlalchemy import create_engine, text
 from sqlalchemy.orm import sessionmaker
 
 from wxfs.fake_data import locations as locations_data
@@ -76,8 +76,9 @@ def main(dsn, actions):
     :param actions: List of actions... Can be "create", "populate", or a list of both
     """
     engine = create_engine(dsn)
+    db_connection = engine.connect()
 
-    engine.execute("SET search_path = wxfs, public")
+    db_connection.execute(text("SET search_path = wxfs, public"))
 
     if "create" in actions:
         create_database(engine)

--- a/wxfs/database/demo/database.py
+++ b/wxfs/database/demo/database.py
@@ -47,12 +47,8 @@ def populate(session):
                             "variables, anomaly, smoothing",
                         ),
                         "creationDate": parse_time(file_data["creationDate"]),
-                        "timePeriodStart": parse_time(
-                            file_data["timePeriod"]["start"]
-                        ),
-                        "timePeriodEnd": parse_time(
-                            file_data["timePeriod"]["end"]
-                        ),
+                        "timePeriodStart": parse_time(file_data["timePeriod"]["start"]),
+                        "timePeriodEnd": parse_time(file_data["timePeriod"]["end"]),
                         "location": location,
                     },
                     {"filepath": "filepath"},

--- a/wxfs/fake_data/__init__.py
+++ b/wxfs/fake_data/__init__.py
@@ -24,7 +24,7 @@ def makeWxFile(tStart, tEnd):
         "creationDate": today,
         "dataSource": "CWEC2016",
         "designDataType": "TMY",
-        "scenario": "RCP8.5",
+        "scenario": "RCP85",
         "timePeriod": {"start": tStart, "end": tEnd},
         "ensembleStatistic": "median",
         "variables": "all thermodynamic",
@@ -39,7 +39,7 @@ def makeSummaryFile():
     file = {
         **makeFileCommon(),
         "fileType": "summary",
-        "scenario": "RCP8.5",
+        "scenario": "RCP85",
         "ensembleStatistic": "multiple",
         "timePeriod": "all",
         "variables": "all thermodynamic",

--- a/wxfs/fake_data/__init__.py
+++ b/wxfs/fake_data/__init__.py
@@ -76,13 +76,7 @@ def makeLocation(city, province, country, code, latitude, longitude, elevation):
     return location
 
 
-makeLocation(
-    "Abbotsford Intl AP", "BC", "CAN", "711080", 49.02530, -122.3600, 59.1
-),
+makeLocation("Abbotsford Intl AP", "BC", "CAN", "711080", 49.02530, -122.3600, 59.1),
 makeLocation("Agassiz", "BC", "CAN", "711130", 49.24310, -121.7603, 19.3),
-makeLocation(
-    "Blue River AP", "XX", "CAN", "718830", 52.12910, -119.2895, 682.8
-),
-makeLocation(
-    "Bonilla Island", "XX", "CAN", "714840", 53.49280, -130.6390, 12.5
-),
+makeLocation("Blue River AP", "XX", "CAN", "718830", 52.12910, -119.2895, 682.8),
+makeLocation("Bonilla Island", "XX", "CAN", "714840", 53.49280, -130.6390, 12.5),

--- a/wxfs/indexer/__init__.py
+++ b/wxfs/indexer/__init__.py
@@ -109,12 +109,9 @@ def index_location(sesh, version, filepath):
             # Does this need to be pre-checked before doing any database activities?
             logger.warning("Shit, locations aren't all the same.")
         if summary_filepath is not None:
-            files.append(index_summary_file(sesh, location, summary_filepath))
+            files.append(index_summary_file(sesh, location, version, summary_filepath))
     else:
         logger.info(f"{filepath} does not contain any recognized files")
-
-    #find or create the version entry for these files.
-    version = find_or_insert(sesh, Version, {"name": version}, {})
 
     return files
 
@@ -140,16 +137,17 @@ def index_wx_file(sesh, version, filepath):
             )
             return None
         location = find_or_insert(sesh, Location, location_info, {})
+        ver = find_or_insert(sesh, Version, {"name": version}, {})
         wx_file = find_or_insert(
             sesh,
             WxFile,
-            {"fileType": "weather", **wx_file_info, "location": location, "version": version},
+            {"fileType": "weather", **wx_file_info, "location": location, "version": ver},
             {"filepath": filepath},
         )
         return wx_file
 
 
-def index_summary_file(sesh, location, filepath):
+def index_summary_file(sesh, location, version, filepath):
     """Index a summary file into the database.
 
     A summary file does not contain enough information to determine its location,
@@ -162,10 +160,12 @@ def index_summary_file(sesh, location, filepath):
     """
     logger.info(f"Indexing summary file {filepath}")
     check_extension(filepath, summary_file_extension)
+    
+    ver = find_or_insert(sesh, Version, {"name": version}, {})
     summary_file = find_or_insert(
         sesh,
         SummaryFile,
-        {"fileType": "summary", "location": location},
+        {"fileType": "summary", "location": location, "version": ver},
         {"filepath": filepath},
     )
     return summary_file

--- a/wxfs/indexer/__init__.py
+++ b/wxfs/indexer/__init__.py
@@ -11,7 +11,7 @@ the existing collection of weather files now at PCIC.
 import os
 import logging
 
-from wxfs.database import Location, WxFile, SummaryFile, Version
+from wxfs.database import Location, WxFile, SummaryFile
 from wxfs.indexer.file_parsing import get_wx_file_info, summarize_attribute
 from wxfs.indexer.db_helpers import find_or_insert
 
@@ -135,7 +135,6 @@ def index_wx_file(sesh, version, filepath):
             logger.info(f"Weather file {filepath} could not be processed, skipping")
             return None
         location = find_or_insert(sesh, Location, location_info, {})
-        ver = find_or_insert(sesh, Version, {"name": version}, {})
         wx_file = find_or_insert(
             sesh,
             WxFile,
@@ -143,7 +142,7 @@ def index_wx_file(sesh, version, filepath):
                 "fileType": "weather",
                 **wx_file_info,
                 "location": location,
-                "version": ver,
+                "version": version,
             },
             {"filepath": filepath},
         )
@@ -164,14 +163,13 @@ def index_summary_file(sesh, location, scenario, version, filepath):
     logger.info(f"Indexing summary file {filepath}")
     check_extension(filepath, summary_file_extension)
 
-    ver = find_or_insert(sesh, Version, {"name": version}, {})
     summary_file = find_or_insert(
         sesh,
         SummaryFile,
         {
             "fileType": "summary",
             "location": location,
-            "version": ver,
+            "version": version,
             "scenario": scenario,
         },
         {"filepath": filepath},

--- a/wxfs/indexer/__init__.py
+++ b/wxfs/indexer/__init__.py
@@ -85,15 +85,12 @@ def index_location(sesh, version, filepath):
                 summary_filepath = path
             else:
                 logger.debug(f"Found unknown type of file {path}")
-    
+
     files = [index_wx_file(sesh, version, filepath) for filepath in wx_filepaths]
-    
 
     # index_wx_file() can return None if it skips a file. Filter these
     # from the results lest the following loops crash and burn
-    skipped = [
-        filepath for x, filepath in zip(files, wx_filepaths) if x is None
-    ]
+    skipped = [filepath for x, filepath in zip(files, wx_filepaths) if x is None]
     logger.info(
         "The following files were not indexed for a variety of reasons: %s",
         skipped,
@@ -110,7 +107,9 @@ def index_location(sesh, version, filepath):
             # Does this need to be pre-checked before doing any database activities?
             logger.warning("Shit, locations aren't all the same.")
         if summary_filepath is not None:
-            files.append(index_summary_file(sesh, location, scenario, version, summary_filepath))
+            files.append(
+                index_summary_file(sesh, location, scenario, version, summary_filepath)
+            )
     else:
         logger.info(f"{filepath} does not contain any recognized files")
 
@@ -133,16 +132,19 @@ def index_wx_file(sesh, version, filepath):
     with open(filepath, "r") as file:
         location_info, wx_file_info = get_wx_file_info(file)
         if location_info is None or wx_file_info is None:
-            logger.info(
-                f"Weather file {filepath} could not be processed, skipping"
-            )
+            logger.info(f"Weather file {filepath} could not be processed, skipping")
             return None
         location = find_or_insert(sesh, Location, location_info, {})
         ver = find_or_insert(sesh, Version, {"name": version}, {})
         wx_file = find_or_insert(
             sesh,
             WxFile,
-            {"fileType": "weather", **wx_file_info, "location": location, "version": ver},
+            {
+                "fileType": "weather",
+                **wx_file_info,
+                "location": location,
+                "version": ver,
+            },
             {"filepath": filepath},
         )
         return wx_file
@@ -161,12 +163,17 @@ def index_summary_file(sesh, location, scenario, version, filepath):
     """
     logger.info(f"Indexing summary file {filepath}")
     check_extension(filepath, summary_file_extension)
-    
+
     ver = find_or_insert(sesh, Version, {"name": version}, {})
     summary_file = find_or_insert(
         sesh,
         SummaryFile,
-        {"fileType": "summary", "location": location, "version": ver, "scenario": scenario},
+        {
+            "fileType": "summary",
+            "location": location,
+            "version": ver,
+            "scenario": scenario,
+        },
         {"filepath": filepath},
     )
     return summary_file
@@ -176,6 +183,4 @@ def check_extension(filepath, extension):
     """Raise an error if filepath does not have specified extension."""
     name, ext = os.path.splitext(filepath)
     if ext != extension:
-        raise ValueError(
-            f"File {filepath} does not have extension '{extension}'."
-        )
+        raise ValueError(f"File {filepath} does not have extension '{extension}'.")

--- a/wxfs/indexer/file_parsing.py
+++ b/wxfs/indexer/file_parsing.py
@@ -19,6 +19,13 @@ def get_wx_file_info(
     """Parse a weather file (.epw) and return essential info, namely the information
     that characterizes its location and the weather file data. Some of this information
     is externally determined or determined from its filename.
+
+    The .EPW format specification is flexible, and we have seen and support two
+    different strategies to formatting metadata in these files. "Format 1" puts most metadata
+    in the LOCATION line; "Format 2" puts more metadata in COMMENT lines. We distinguish
+    between them here by looking for a | in the LOCATION line, which in Format 1
+    files comes between the location metadata and additional metadata unrelated to
+    location.
     """
     scenario_part = None
 
@@ -107,7 +114,7 @@ def parse_file_name(name):
             "country": match.group("country"),
             "province": match.group("province"),
             "city": match.group("city"),
-            "code": "fakecode" if cmip6 else match.group("code"),
+            "code": None if cmip6 else match.group("code"),
             "dataSource": match.group("dataSource"),
         }
     return None

--- a/wxfs/indexer/file_parsing.py
+++ b/wxfs/indexer/file_parsing.py
@@ -183,12 +183,12 @@ def summarize_attribute(files, attribute):
     """Used to populate metadata for summary files. Accepts a collection of files
     and the name of an attribute. If every file has the same_value for that 
     attribute, returns that value. Otherwise returns the string 'multiple'"""
-    values = set([file[attribute] for file in files])
+    values = set([getattr(file, attribute) for file in files])
     
-    if values.length == 0:
+    if len(values) == 0:
         return None
-    elif values.length == 1:
-        return values[0]
+    elif len(values) == 1:
+        return list(values)[0]
     else:
         return "multiple"
     

--- a/wxfs/indexer/file_parsing.py
+++ b/wxfs/indexer/file_parsing.py
@@ -31,7 +31,7 @@ def get_wx_file_info(
 
     line = wx_file.readline()
     if ver1_metadata_sep in line:
-        # This appears to contain version 1 format metadata
+        # This appears to contain format 1 metadata
         try:
             location_part, _, _, creation_date_part = line.split(ver1_metadata_sep)
         except ValueError as e:
@@ -42,7 +42,7 @@ def get_wx_file_info(
             )
             return None, None
     else:
-        # Assume version 2 format metadata
+        # Assume format 2 metadata
         location_part = line
 
         creation_date_part = None

--- a/wxfs/indexer/file_parsing.py
+++ b/wxfs/indexer/file_parsing.py
@@ -23,6 +23,8 @@ def get_wx_file_info(
     scenario_part = None
     
     line = wx_file.readline()
+    print("beginning line is")
+    print(line)
     if ver1_metadata_sep in line:
         # This appears to contain version 1 format metadata
         try:
@@ -44,7 +46,7 @@ def get_wx_file_info(
 
 
         line_num = 1
-        while not creation_date_part and scenario_part:
+        while not creation_date_part or not scenario_part:
             line_num += 1
             if line_num > ver2_metadata_max_line_number:
                 logger.error(
@@ -52,10 +54,14 @@ def get_wx_file_info(
                 )
                 return None, None
             line = wx_file.readline()
+            print("line is")
+            print(line)
             if line.startswith(ver2_scenario_prefix):
+                print("found scenario")
                 scenario_part = line
             elif line.startswith(ver2_creation_prefix):
                 creation_date_part = line
+                print("found creation")
 
 
     location_info = parse_location_part(location_part)
@@ -137,17 +143,24 @@ def parse_creation_date_part(part):
     return None
 
 def parse_scenario_part(part): 
-    """Parse the emmissions scenario from the comment line"""
+    """Parse the emissions scenario from the comment line"""
     # just look for a word that starts either RCP or SSP.
+    scenarios = {
+        "RCP85": "RCP 8.5",
+        "RCP45": "RCP 4.5",
+        "RCP26": "RCP 2.6",
+        "SSP126": "SSP1-2.6",
+        "SSP245": "SSP2-4.5",
+        "SSP585": "SSP5-8.5"
+        }
     if part:
-        regex = re.compile(r"(RCP||SSP)\d*")
-        match = regex.search(part)
-        if match:
-            print("match is")
-            print(match)
-            return match.group()
+        print("scenario part is")
+        print(part)
+        for code in scenarios:
+            if code in part:
+                return scenarios[code]
     logger.info ("No scenario data found. Defaulting to RCP 8.5")
-    return "RCP85"
+    return "RCP 8.5"
 
 def get_time_period_centre(time_period):
     """

--- a/wxfs/indexer/file_parsing.py
+++ b/wxfs/indexer/file_parsing.py
@@ -12,13 +12,16 @@ logger = logging.getLogger(__name__)
 def get_wx_file_info(
     wx_file,
     ver1_metadata_sep=" | ",
-    ver2_metadata_prefix="COMMENTS 2",
+    ver2_scenario_prefix="COMMENTS 1",
+    ver2_creation_prefix="COMMENTS 2",
     ver2_metadata_max_line_number=10,
 ):
     """Parse a weather file (.epw) and return essential info, namely the information
     that characterizes its location and the weather file data. Some of this information
     is externally determined or determined from its filename.
     """
+    scenario_part = None
+    
     line = wx_file.readline()
     if ver1_metadata_sep in line:
         # This appears to contain version 1 format metadata
@@ -36,9 +39,12 @@ def get_wx_file_info(
     else:
         # Assume version 2 format metadata
         location_part = line
+        
+        creation_date_part = None
+
 
         line_num = 1
-        while not line.startswith(ver2_metadata_prefix):
+        while not creation_date_part and scenario_part:
             line_num += 1
             if line_num > ver2_metadata_max_line_number:
                 logger.error(
@@ -46,9 +52,11 @@ def get_wx_file_info(
                 )
                 return None, None
             line = wx_file.readline()
-        # There's actually more than creation date in this line,
-        # but we don't care, parser is up to it.
-        creation_date_part = line
+            if line.startswith(ver2_scenario_prefix):
+                scenario_part = line
+            elif line.startswith(ver2_creation_prefix):
+                creation_date_part = line
+
 
     location_info = parse_location_part(location_part)
 
@@ -61,7 +69,7 @@ def get_wx_file_info(
             "creationDate": parse_creation_date_part(creation_date_part),
             "dataSource": file_info["dataSource"],
             "designDataType": "TMY",
-            "scenario": "RCP8.5",
+            "scenario": parse_scenario_part(scenario_part),
             "timePeriodStart": datetime.datetime(
                 time_period_centre_year - 15, 1, 1
             ),
@@ -128,6 +136,18 @@ def parse_creation_date_part(part):
         return datetime.datetime.strptime(match.group("date"), "%Y-%m-%d")
     return None
 
+def parse_scenario_part(part): 
+    """Parse the emmissions scenario from the comment line"""
+    # just look for a word that starts either RCP or SSP.
+    if part:
+        regex = re.compile(r"(RCP||SSP)\d*")
+        match = regex.search(part)
+        if match:
+            print("match is")
+            print(match)
+            return match.group()
+    logger.info ("No scenario data found. Defaulting to RCP 8.5")
+    return "RCP85"
 
 def get_time_period_centre(time_period):
     """
@@ -137,3 +157,18 @@ def get_time_period_centre(time_period):
     """
     year = int(time_period[0:4])
     return year + 5
+
+def summarize_attribute(files, attribute):
+    """Used to populate metadata for summary files. Accepts a collection of files
+    and the name of an attribute. If every file has the same_value for that 
+    attribute, returns that value. Otherwise returns the string 'multiple'"""
+    values = set([file[attribute] for file in files])
+    
+    if values.length == 0:
+        return None
+    elif values.length == 1:
+        return values[0]
+    else:
+        return "multiple"
+    
+    

--- a/wxfs/openapi/api-spec.yaml
+++ b/wxfs/openapi/api-spec.yaml
@@ -297,10 +297,10 @@ components:
           enum: ["TMY", "XMY", "TSY", "AMY", "design day"]  # To be extended.
         scenario:
           description: |
-            RCP (represenatative concentration pathway) in model(s) used to
-            generate this file.
+            RCP (represenatative concentration pathway) or SSP (shared 
+			socioeconomic pathway) in model(s) used to generate this file.
           type: string
-          enum: ["RCP2.6", "RCP4.5", "RCP8.5"]
+          enum: ["RCP 2.6", "RCP 4.5", "RCP 8.5", "SSP1-2.6", "SSP2-4.5", "SSP5-8.5"]
         timePeriod:
           $ref: '#/components/schemas/TimePeriod'
         ensembleStatistic:

--- a/wxfs/openapi/api-spec.yaml
+++ b/wxfs/openapi/api-spec.yaml
@@ -260,6 +260,16 @@ components:
         fileType:
           type: string
           enum: [summary, weather]
+		version:
+		  description: CMIP version data models belong to
+		  type: string
+		  enum: ["cmip5", "cmip6"]
+		scenario:
+		  description: |
+            RCP (represenatative concentration pathway) or SSP (shared 
+            socioeconomic pathway) in model(s) used to generate this file.
+		  type: string
+		  enum: ["RCP 2.6", "RCP 4.5", "RCP 8.5", "SSP1-2.6", "SSP2-4.5", "SSP5-8.5"]
         filepath:
           description: Filepath in storage to file contents
           type: string
@@ -274,6 +284,8 @@ components:
       required:
         - id
         - fileType
+        - version
+        - scenario
         - filepath
         - selfUri
         - contentUri
@@ -295,12 +307,6 @@ components:
             - `TMY`: Typical meteorological year
           type: string
           enum: ["TMY", "XMY", "TSY", "AMY", "design day"]  # To be extended.
-        scenario:
-          description: |
-            RCP (represenatative concentration pathway) or SSP (shared 
-			socioeconomic pathway) in model(s) used to generate this file.
-          type: string
-          enum: ["RCP 2.6", "RCP 4.5", "RCP 8.5", "SSP1-2.6", "SSP2-4.5", "SSP5-8.5"]
         timePeriod:
           $ref: '#/components/schemas/TimePeriod'
         ensembleStatistic:

--- a/wxfs/openapi/api-spec.yaml
+++ b/wxfs/openapi/api-spec.yaml
@@ -260,16 +260,16 @@ components:
         fileType:
           type: string
           enum: [summary, weather]
-		version:
-		  description: CMIP version data models belong to
-		  type: string
-		  enum: ["cmip5", "cmip6"]
-		scenario:
-		  description: |
+        version:
+          description: CMIP version data models belong to
+          type: string
+          enum: ["cmip5", "cmip6"]
+        scenario:
+          description: |
             RCP (represenatative concentration pathway) or SSP (shared 
             socioeconomic pathway) in model(s) used to generate this file.
-		  type: string
-		  enum: ["RCP 2.6", "RCP 4.5", "RCP 8.5", "SSP1-2.6", "SSP2-4.5", "SSP5-8.5"]
+          type: string
+          enum: ["RCP 2.6", "RCP 4.5", "RCP 8.5", "SSP1-2.6", "SSP2-4.5", "SSP5-8.5"]
         filepath:
           description: Filepath in storage to file contents
           type: string


### PR DESCRIPTION
Adds a new file attribute to the database and indexing scripts, "version".  Version is specified during indexing, and is stored in a table of the same name. Also adds a little extra handling around "scenario" values, as the cmip6 data has multiple scenarios, and cmip5 had only one.

----------------------------------------------
I have two broad "design" questions I'd like to hash out with help from @rod-glover or @jameshiebert before getting into reviewing code line-by-line.

**What should the relationship between a CMIP5 `location` and its CMIP6 equivalent be?**

Matching CMIP5 and CMIP6 locations from ECCC have different names (CMIP6 names are allcaps, and some of them have different phrasing) and coordinates (CMIP5 andCMIP6 location definitions from ECCC have different numbers of significant figures in the latitude and longitude). Due to the "different" coordinates, at present, the indexing scrip creates separate `location` entries in the `locations` table for CMIP5 and CMIP6. This is not currently a problem, as Stephen indicates that users of this dataset will not want to combine data from CMIP5 and CMIP6, and they should be displayed separately.

While this isn't a problem at present, it might be a problem in the future if we add a third dataset to the database, so we might want to consider a more robust solution that doesn't make ECCC's arbitrary formatting load-bearing, and makes "location" mean something other than its plain English meaning.

The location `code` attribute has not changed between versions. We could match on `code` during the indexing process, instead of latitude, longitude, and altitude. This would be a relatively straightforward change, but combining the locations would lose the unique CMIP5 and CMIP6 names. I'm not sure how important that is, but we could add a separate `location_names` table to track them, if needed, which is a more complicated change.

**Should we have a REST API object for version?**

Currently `version` is treated as an attribute of a `file`. We could instead make a `version` API and maybe do things like `/versions/cmip6/locations`. This might be useful for the standpoint of less filtering work for the front end, but it would add some complexity here. Maybe we should wait on this to see if the front end is slow.

------------------------------------------------
[Here](https://beehive.pacificclimate.org/wx-files/app) is a demo, but since no work has been done on the front end yet, it shows CMIP6 locations (allcaps) and CMIP5 locations (normal capitalization) jumbled together.

resolves #23