### PR TITLE
use pre-pings to maintain connectivity

### DIFF
--- a/wxfs/__init__.py
+++ b/wxfs/__init__.py
@@ -32,6 +32,7 @@ def create_app(config_override={}):
         SQLALCHEMY_TRACK_MODIFICATIONS=False,
         SQLALCHEMY_ECHO=False,
     )
+    flask_app.config["SQLALCHEMY_ENGINE_OPTIONS"] = {"pool_pre_ping": True}
     flask_app.config.update(config_override)
 
     app_db = SQLAlchemy(flask_app)


### PR DESCRIPTION
We have been seeing a few 500s from this service, seemingly caused by dropped connections. This PR enables sqlalchemy's "pre-ping" functionality, which sends an SQL statement like `SELECT 1` to make sure connections are up before attempting a real `SELECT`. Hopefully this will improve the reliability of the server.

Resolves #32 